### PR TITLE
Allow arbitrary additional arguments to `go list`

### DIFF
--- a/list.go
+++ b/list.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"time"
@@ -121,13 +122,18 @@ func NewExecError(err error, stderr string) *ExecError {
 	return &ExecError{err, stderr}
 }
 
-func GoList(workDir string, path string) ([]Package, error) {
-	cmd := exec.Command("go", "list", "-json", path)
+func GoList(workDir string, path string, args ...string) ([]Package, error) {
+	cmdName := "go"
+	cmdArgs := append([]string{"list", "-json"}, args...)
+	cmdArgs = append(cmdArgs, path)
+	cmd := exec.Command(cmdName, cmdArgs...)
 	cmd.Dir = workDir
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
+
+	log.Printf("[DEBUG] Executing command %s %q", cmdName, cmdArgs)
 
 	err := cmd.Run()
 	if err != nil {
@@ -152,14 +158,19 @@ func GoList(workDir string, path string) ([]Package, error) {
 	return packages, nil
 }
 
-func GoListModule(workDir string, path string) ([]Module, error) {
-	cmd := exec.Command("go", "list", "-m", "-json", path)
+func GoListModule(workDir string, path string, args ...string) ([]Module, error) {
+	cmdName := "go"
+	cmdArgs := append([]string{"list", "-m", "-json"}, args...)
+	cmdArgs = append(cmdArgs, path)
+	cmd := exec.Command(cmdName, cmdArgs...)
 	cmd.Env = append(os.Environ(), "GO111MODULE=on")
 	cmd.Dir = workDir
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
+
+	log.Printf("[DEBUG] Executing command %s %q", cmdName, cmdArgs)
 
 	err := cmd.Run()
 	if err != nil {


### PR DESCRIPTION
This will allow us to pass `-mod=vendor`, for example.